### PR TITLE
Fix bug with search filter pipe

### DIFF
--- a/src/dropdown/search-filter.pipe.ts
+++ b/src/dropdown/search-filter.pipe.ts
@@ -22,7 +22,7 @@ export class MultiSelectSearchFilter implements PipeTransform {
 
     const isUnderLimit = options.length <= limit;
 
-    if (this._searchCache[str]) {
+    if (this._searchCache.hasOwnProperty(str)) {
       return isUnderLimit ? this._searchCache[str] : this._limitRenderedItems(this._searchCache[str], renderLimit);
     }
 


### PR DESCRIPTION
When you're searching for "constructor" it returns the javascript constructor object and breaks the dropdown